### PR TITLE
lowercase result & exclamation point in charmap

### DIFF
--- a/slug.js
+++ b/slug.js
@@ -38,6 +38,7 @@ function slug(string, opts) {
     }
     result = result.replace(/^\s+|\s+$/g, ''); // trim leading/trailing spaces
     result = result.replace(/[-\s]+/g, opts.replacement); // convert spaces
+    result = result.toLowerCase(); //keep it lowercase
     return result.replace(opts.replacement+"$",''); // remove trailing separator
 };
 


### PR DESCRIPTION
a PR with two separate things. 

1) @jbraithwaite's fork keeps our end result completely lowercase by including the unmodified characters in his call toLowerCase() just before returning the result, so regular capitalized letters will get lowercased. Check out his work [on this commit](https://github.com/jbraithwaite/node-slug/commit/a0a97f8fd5046982e1a2de38be6d1da6d232ce42).

2) Adding the exclamation point symbol as a key in our charmap with a single space character value for its associated replacement string. 

Why the single space character? Because I want to remove any exclamation points from input strings containing the exclamation punctuation marks! We might consider doing this as a default so that's the 2nd part of the PR
