### PR TITLE
conform with RFC 3986

### DIFF
--- a/slug.js
+++ b/slug.js
@@ -33,7 +33,7 @@ function slug(string, opts) {
             }
             char = char.replace(/^\s+|\s+$/g, '');
         }
-        char = char.replace(/[^\w\s$\*\_\+~\.\(\)\'\"\!\-:@]/g, ''); // allowed
+        char = char.replace(/[^\w\s\-\.\_~]/g, ''); // allowed
         result += char;
     }
     result = result.replace(/^\s+|\s+$/g, ''); // trim leading/trailing spaces

--- a/test/slug.test.coffee
+++ b/test/slug.test.coffee
@@ -18,7 +18,7 @@ describe 'slug', ->
         [slug 'foo] bar baz'].should.eql ['foo-bar-baz']
 
     it 'should leave allowed chars', ->
-        allowed = ['*', '+', '~', '.', '(', ')', "'", '"', '!', ':', '@']
+        allowed = ['.', '_', '~']
         for a in allowed
             [slug "foo #{a} bar baz"].should.eql ["foo-#{a}-bar-baz"]
 
@@ -123,14 +123,21 @@ describe 'slug', ->
 
     it 'should replace symbols', ->
         char_map = {
-            '©':'(c)', 'œ': 'oe', 'Œ': 'OE', '∑': 'sum', '®': '(r)', '†': '+',
-            '“': '"', '”': '"', '‘': "'", '’': "'", '∂': 'd', 'ƒ': 'f', '™': 'tm',
-            '℠': 'sm', '…': '...', '˚': 'o', 'º': 'o', 'ª': 'a', '•': '*',
+            '©':'c', 'œ': 'oe', 'Œ': 'OE', '∑': 'sum', '®': 'r',
+            '∂': 'd', 'ƒ': 'f', '™': 'tm',
+            '℠': 'sm', '…': '...', '˚': 'o', 'º': 'o', 'ª': 'a'
             '∆': 'delta', '∞': 'infinity', '♥': 'love', '&': 'and', '|': 'or',
             '<': 'less', '>': 'greater'
         }
         for char, replacement of char_map
             [slug "foo #{char} bar baz"].should.eql ["foo-#{replacement}-bar-baz"]
+
+    it 'should strip symbols', ->
+        char_map = [
+            '†', '“', '”', '‘', '’', '•'
+        ]
+        for char in char_map
+            [slug "foo #{char} bar baz"].should.eql ["foo-bar-baz"]
 
     it 'should replace unicode', ->
         char_map = {


### PR DESCRIPTION
This pull requests makes sure that `slug` only outputs correct url's that conforms to RFC 3986. This is an agreed upon standard of what characters are allowed in an url, and I think that this is something that we should adhere to.

To quote section 2.3 of RFC 3986:

> Characters that are allowed in a URI but do not have a reserved purpose are called unreserved. These include uppercase and lowercase letters, decimal digits, hyphen, period, underscore, and tilde.
