### PR TITLE
Support empty string as replacement and fix tests

### DIFF
--- a/slug.js
+++ b/slug.js
@@ -10,14 +10,15 @@ function symbols(code) {
 }
 
 function slug(string, opts) {
-    opts = opts || {};
     string = string.toString();
     if ('string' === typeof opts)
         opts = {replacement:opts};
+    opts = opts || {};
     opts.mode = opts.mode || slug.defaults.mode;
     var defaults = slug.defaults.modes[opts.mode];
     ['replacement','multicharmap','charmap','remove'].forEach(function (key) {
-        opts[key] = opts[key] || defaults[key];
+        if ('replacement' !== key || 'string' !== typeof opts[key])
+            opts[key] =  opts[key] || defaults[key];
     });
     if ('undefined' === typeof opts.symbols)
         opts.symbols = defaults.symbols;

--- a/test/slug.test.coffee
+++ b/test/slug.test.coffee
@@ -8,6 +8,7 @@ describe 'slug', ->
     it 'should replace whitespaces with replacement', ->
         [slug 'foo bar baz'].should.eql ['foo-bar-baz']
         [slug 'foo bar baz', '_'].should.eql ['foo_bar_baz']
+        [slug 'foo bar baz', ''].should.eql ['foobarbaz']
 
     it 'should remove trailing space if any', ->
         [slug ' foo bar baz '].should.eql ['foo-bar-baz']

--- a/test/slug.test.coffee
+++ b/test/slug.test.coffee
@@ -17,10 +17,11 @@ describe 'slug', ->
         [slug 'foo- bar baz'].should.eql ['foo-bar-baz']
         [slug 'foo] bar baz'].should.eql ['foo-bar-baz']
 
-    it 'should leave allowed chars', ->
+    it 'should leave allowed chars in rfc3986 mode', ->
         allowed = ['.', '_', '~']
         for a in allowed
-            [slug "foo #{a} bar baz"].should.eql ["foo-#{a}-bar-baz"]
+            [slug "foo #{a} bar baz",
+                mode: "rfc3986"].should.eql ["foo-#{a}-bar-baz"]
 
     it 'should replace latin chars', ->
         char_map = {
@@ -121,7 +122,7 @@ describe 'slug', ->
             replacement = replacement.replace ' ', '-'
             [slug "foo #{char} bar baz"].should.eql ["foo-#{replacement}-bar-baz"]
 
-    it 'should replace symbols', ->
+    it 'should replace symbols in rfc3986 mode', ->
         char_map = {
             '©':'c', 'œ': 'oe', 'Œ': 'OE', '∑': 'sum', '®': 'r',
             '∂': 'd', 'ƒ': 'f', '™': 'tm',
@@ -130,7 +131,26 @@ describe 'slug', ->
             '<': 'less', '>': 'greater'
         }
         for char, replacement of char_map
+            [slug "foo #{char} bar baz",
+                mode: "rfc3986"].should.eql ["foo-#{replacement}-bar-baz"]
+
+    it 'should replace symbols in pretty mode', ->
+        char_map = {
+            '©':'c', 'œ': 'oe', 'Œ': 'OE', '∑': 'sum', '®': 'r',
+            '∂': 'd', 'ƒ': 'f', '™': 'tm',
+            '℠': 'sm', '˚': 'o', 'º': 'o', 'ª': 'a'
+            '∆': 'delta', '∞': 'infinity', '♥': 'love', '&': 'and', '|': 'or',
+            '<': 'less', '>': 'greater'
+        }
+        for char, replacement of char_map
             [slug "foo #{char} bar baz"].should.eql ["foo-#{replacement}-bar-baz"]
+
+    it 'should remove ellipsis in pretty mode', ->
+        char_map = {
+            '…': '...'
+        }
+        for char, replacement of char_map
+            [slug "foo #{char} bar baz"].should.eql ["foo-bar-baz"]
 
     it 'should strip symbols', ->
         char_map = [


### PR DESCRIPTION
This change allows using an empty string ('') as a replacement and adds a test for it.

It also fixes two failing tests by setting `mode: "rfc3986"` and adds two tests for the default `pretty` mode.