### PR TITLE
Add support for missing unicode symbols resource

### DIFF
--- a/slug.js
+++ b/slug.js
@@ -3,7 +3,11 @@
 var _symbols, removelist;
 function symbols(code) {
     if (_symbols) return _symbols[code];
-    _symbols = require('unicode/category/So');
+    try {
+        _symbols = require('unicode/category/So');
+    } catch (e) {
+        _symbols = {};
+    }
     removelist = ['sign','cross','of','symbol','staff','hand','black','white']
         .map(function (word) {return new RegExp(word, 'gi')});
     return _symbols[code];


### PR DESCRIPTION
By wrapping the `require` call in a try/catch statement, running `slug` will work with browserified CommonJS dependants.

So even when `require` is available, a missing `unicode/category/So` will not fail the process.
Such a file is missing when, for example, `browserify` is run with [`--exclude`](https://github.com/substack/node-browserify#usage).

Note: the test failed on this, but that seems to happen due to failures on the master branch.