### PR TITLE
default lowercase slugs fixes #32

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ print(slug('i ♥ unicode', '_')) // If you prefer something else then `-` as se
 // > i_love_unicode
 
 slug.charmap['♥'] = 'freaking love' // change default charmap or use option {charmap:{…}} as 2. argument
-print(slug('I ♥ UNICODE').toLowerCase()) // If you prefer lower case
-// > i-freaking-love-unicode
+print(slug('I ♥ UNICODE', {lowercase: false})) // If you prefer not lower case
+// > I-freaking-love-UNICODE
 
 print(slug('i <3 unicode'))
 // > i-love-unicode

--- a/slug.js
+++ b/slug.js
@@ -15,6 +15,7 @@ function slug(string, opts) {
     if ('string' === typeof opts)
         opts = {replacement:opts};
     opts.mode = opts.mode || slug.defaults.mode;
+    opts.lowercase = opts.lowercase === false? false : slug.defaults.lowercase;
     var defaults = slug.defaults.modes[opts.mode];
     ['replacement','multicharmap','charmap','remove'].forEach(function (key) {
         opts[key] = opts[key] || defaults[key];
@@ -57,11 +58,16 @@ function slug(string, opts) {
     }
     result = result.replace(/^\s+|\s+$/g, ''); // trim leading/trailing spaces
     result = result.replace(/[-\s]+/g, opts.replacement); // convert spaces
-    return result.replace(opts.replacement+"$",''); // remove trailing separator
+    result = result.replace(opts.replacement+"$",''); // remove trailing separator
+    if (opts.lowercase) {
+      result = result.toLowerCase()
+    }
+    return result;
 };
 
 slug.defaults = {
     mode: 'pretty',
+    lowercase: true
 };
 
 slug.multicharmap = slug.defaults.multicharmap = {

--- a/test/slug.test.coffee
+++ b/test/slug.test.coffee
@@ -36,7 +36,7 @@ describe 'slug', ->
             'ý': 'y', 'þ': 'th', 'ÿ': 'y', 'ẞ': 'SS'
         }
         for char, replacement of char_map
-            [slug "foo #{char} bar baz"].should.eql ["foo-#{replacement}-bar-baz"]
+            [slug "foo #{char} bar baz"].should.eql ["foo-#{replacement}-bar-baz".toLowerCase()]
 
     it 'should replace greek chars', ->
         char_map = {
@@ -52,7 +52,7 @@ describe 'slug', ->
             'Ϋ':'Y'
         }
         for char, replacement of char_map
-            [slug "foo #{char} bar baz"].should.eql ["foo-#{replacement}-bar-baz"]
+            [slug "foo #{char} bar baz"].should.eql ["foo-#{replacement}-bar-baz".toLowerCase()]
 
     it 'should replace turkish chars', ->
         char_map = {
@@ -60,7 +60,7 @@ describe 'slug', ->
             'ö':'o', 'Ö':'O', 'ğ':'g', 'Ğ':'G'
         }
         for char, replacement of char_map
-            [slug "foo #{char} bar baz"].should.eql ["foo-#{replacement}-bar-baz"]
+            [slug "foo #{char} bar baz"].should.eql ["foo-#{replacement}-bar-baz".toLowerCase()]
 
     it 'should replace cyrillic chars', ->
         char_map = {
@@ -78,7 +78,7 @@ describe 'slug', ->
         for char, replacement of char_map
             expected = "foo-#{replacement}-bar-baz"
             expected = "foo-bar-baz" if not replacement
-            [slug "foo #{char} bar baz"].should.eql [expected]
+            [slug "foo #{char} bar baz"].should.eql [expected.toLowerCase()]
 
     it 'should replace czech chars', ->
         char_map = {
@@ -87,7 +87,7 @@ describe 'slug', ->
             'Ů':'U', 'Ž':'Z'
         }
         for char, replacement of char_map
-            [slug "foo #{char} bar baz"].should.eql ["foo-#{replacement}-bar-baz"]
+            [slug "foo #{char} bar baz"].should.eql ["foo-#{replacement}-bar-baz".toLowerCase()]
 
     it 'should replace polish chars', ->
         char_map = {
@@ -96,7 +96,7 @@ describe 'slug', ->
             'Ź':'Z', 'Ż':'Z'
         }
         for char, replacement of char_map
-            [slug "foo #{char} bar baz"].should.eql ["foo-#{replacement}-bar-baz"]
+            [slug "foo #{char} bar baz"].should.eql ["foo-#{replacement}-bar-baz".toLowerCase()]
 
     it 'should replace latvian chars', ->
         char_map = {
@@ -105,7 +105,7 @@ describe 'slug', ->
             'Ķ':'K', 'Ļ':'L', 'Ņ':'N', 'Š':'S', 'Ū':'U', 'Ž':'Z'
         }
         for char, replacement of char_map
-            [slug "foo #{char} bar baz"].should.eql ["foo-#{replacement}-bar-baz"]
+            [slug "foo #{char} bar baz"].should.eql ["foo-#{replacement}-bar-baz".toLowerCase()]
 
     it 'should replace currencies', ->
         char_map = {
@@ -130,7 +130,7 @@ describe 'slug', ->
             '<': 'less', '>': 'greater'
         }
         for char, replacement of char_map
-            [slug "foo #{char} bar baz"].should.eql ["foo-#{replacement}-bar-baz"]
+            [slug "foo #{char} bar baz"].should.eql ["foo-#{replacement}-bar-baz".toLowerCase()]
 
     it 'should strip symbols', ->
         char_map = [
@@ -155,10 +155,6 @@ describe 'slug', ->
         for char in char_map
             [slug "foo #{char} bar baz", symbols:no].should.eql ["foo-bar-baz"]
 
-    it 'should allow forcing lowercase slugs', ->
-        [slug('FOO Bar baZ').toLowerCase()].should.eql ['foo-bar-baz']
-        [slug('FOO Bar baZ', replacement:'_').toLowerCase()].should.eql ['foo_bar_baz']
-
     it 'should allow altering the charmap', ->
         charmap = {
             'f': 'ph', 'o':'0', 'b':'8', 'a':'4', 'r':'2', 'z':'5'
@@ -166,12 +162,22 @@ describe 'slug', ->
         [slug("foo bar baz", {charmap}).toUpperCase()].should.eql ['PH00-842-845']
 
     it 'should replace lithuanian characters', ->
-        slug('ąčęėįšųūžĄČĘĖĮŠŲŪŽ').should.eql 'aceeisuuzACEEISUUZ'
+        slug('ąčęėįšųūžĄČĘĖĮŠŲŪŽ').should.eql 'aceeisuuzaceeisuuz'
 
     it 'should replace multichars', ->
         [slug "w/ <3 && sugar || ☠"].should.eql ['with-love-and-sugar-or-skull-and-bones']
 
     it 'should be flavourable', ->
         text = "It's your journey ... we guide you through."
-        expected = "Its-your-journey-we-guide-you-through"
+        expected = "its-your-journey-we-guide-you-through"
         [slug(text, mode:'pretty')].should.eql [expected]
+
+    it 'should default to lowercase', ->
+      text = "It's Your Journey We Guide You Through."
+      expected = "its-your-journey-we-guide-you-through"
+      [slug(text)].should.eql [expected]
+
+    it 'should allow disabling of lowercase', ->
+      text = "It's Your Journey We Guide You Through."
+      expected = "Its-Your-Journey-We-Guide-You-Through"
+      [slug(text, lowercase: false)].should.eql [expected]


### PR DESCRIPTION
``` javascript
slug('HELLO WORLD') //hello-world

slug('HELLO WORLD', {lowercase: false}) // HELLO-WORLD
```
