### PR TITLE
Removed forEach function call

### DIFF
--- a/slug.js
+++ b/slug.js
@@ -16,17 +16,25 @@ function slug(string, opts) {
         opts = {replacement:opts};
     opts.mode = opts.mode || slug.defaults.mode;
     var defaults = slug.defaults.modes[opts.mode];
-    ['replacement','multicharmap','charmap','remove'].forEach(function (key) {
-        opts[key] = opts[key] || defaults[key];
-    });
+   
+    opts['replacement'] = opts['replacement'] || defaults['replacement'];
+    opts['multicharmap'] = opts['multicharmap'] || defaults['multicharmap'];
+    opts['charmap'] = opts['charmap'] || defaults['charmap'];
+    opts['remove'] = opts['remove'] || defaults['remove'];
+
     if ('undefined' === typeof opts.symbols)
         opts.symbols = defaults.symbols;
+
     var lengths = [];
-    Object.keys(opts.multicharmap).forEach(function (key) {
+    for (var key in opts.multicharmap) {
+        if (!opts.multicharmap.hasOwnProperty(key))
+            continue;
+
         var len = key.length;
         if (lengths.indexOf(len) === -1)
             lengths.push(len);
-    });
+    }
+
     var code, unicode, result = "";
     for (var char, i = 0, l = string.length; i < l; i++) { char = string[i];
         if (!lengths.some(function (len) {
@@ -161,18 +169,25 @@ slug.defaults.modes = {
 
 if (typeof define !== 'undefined' && define.amd) { // AMD
     // dont load symbols table in the browser
-    Object.keys(slug.defaults.modes).forEach(function (key) {
+
+    for (var key in slug.defaults.modes) {
+        if (!slug.defaults.modes.hasOwnProperty(key))
+            continue;
+
         slug.defaults.modes[key].symbols = false;
-    });
+    }
     define([], function () {return slug});
 } else if (typeof module !== 'undefined' && module.exports) { // CommonJS
     symbols(); // preload symbols table
     module.exports = slug;
 } else { // Script tag
     // dont load symbols table in the browser
-    Object.keys(slug.defaults.modes).forEach(function (key) {
+    for (var key in slug.defaults.modes) {
+        if (!slug.defaults.modes.hasOwnProperty(key))
+            continue;
+
         slug.defaults.modes[key].symbols = false;
-    });
+    }
     root.slug = slug;
 }
 


### PR DESCRIPTION
Before I modified code, 2 Tests failed for me, locally 

After I modified the code the same test results are received.  I don't know enough about Unicode to fix the failed tests.

This no longer gives errors when parsed and ran in IE8 may or may not work on IE < 8

I believe that in these use cases .hasOwnProperty check can be skipped, but it was part of a copy/paste fix and it passes the tests so I left it.


