### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,5 @@
     "coffee-script": "~1.7.1"}
 , "bin": {
     "slug": "bin/slug.js"}
-, "licenses" : [
-    { "type": "MIT" ,
-      "url": "http://github.com/dodo/node-slug/raw/master/LICENSE"} ]
+, "license" : "MIT"
 }


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/
