### PR TITLE
Chaining methods instead of multiple assignations

### DIFF
--- a/slug.js
+++ b/slug.js
@@ -61,12 +61,10 @@ function slug(string, opts) {
         if (opts.remove) char = char.replace(opts.remove, ''); // add flavour
         result += char;
     }
-    result = result.replace(/^\s+|\s+$/g, ''); // trim leading/trailing spaces
-    result = result.replace(/[-\s]+/g, opts.replacement); // convert spaces
-    result = result.replace(opts.replacement+"$",''); // remove trailing separator
-    if (opts.lower)
-      result = result.toLowerCase();
-    return result;
+    result = result.replace(/^\s+|\s+$/g, '') // trim leading/trailing spaces
+      .replace(/[-\s]+/g, opts.replacement)   // convert spaces
+      .replace(opts.replacement+"$",'');      // remove trailing separator
+    return (opts.lower) ? result.toLowerCase()  : result;
 };
 
 slug.defaults = {


### PR DESCRIPTION
The two changes I made are :
- Chaining the `.replace()` methode to make only one assignation
- Testing the `opts.lower` on the return statement to avoid another assignation
