### PR TITLE
Add JSHint to project, and fix errors.

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,15 @@
+{
+    "bitwise": true,
+    "curly": true,
+    "eqeqeq": true,
+    "indent": 4,
+    "newcap": true,
+    "noarg": true,
+    "undef": true,
+    "unused": true,
+    "globals": {
+        "define": true,
+        "module": true,
+        "require": true
+    }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 before_script: "npm install --dev"
-script: "npm test"
+script:
+    - "npm run lint"
+    - "npm test"
 language: node_js
 node_js:
     - 0.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+before_install: "npm install npm -g"
 before_script: "npm install --dev"
 script:
     - "npm run lint"

--- a/package.json
+++ b/package.json
@@ -8,10 +8,12 @@
 , "engines": {"node": ">= 0.4.x"}
 , "keywords": ["slugify", "slug", "string", "utf8", "utf-8", "unicode", "url"]
 , "scripts": {
+    "lint": "./node_modules/.bin/jshint slug.js",
     "test": "./node_modules/.bin/mocha ./test/*.test.* --require should --reporter spec --colors --compilers coffee:coffee-script/register"}
 , "dependencies": {
     "unicode": ">= 0.3.1"}
 , "devDependencies": {
+    "jshint": "~2.8.0",
     "mocha": "~1.17.1",
     "should": "~3.1.2",
     "coffee-script": "~1.7.1"}


### PR DESCRIPTION
Added JSHint to project and to build.

Fixed all 18 errors below,

``` console
slug.js: line 5, col 19, Expected '{' and instead saw 'return'.
slug.js: line 8, col 60, Missing semicolon.
slug.js: line 15, col 9, Expected '{' and instead saw 'opts'.
slug.js: line 24, col 9, Expected '{' and instead saw 'opts'.
slug.js: line 27, col 18, 'key' is already defined.
slug.js: line 29, col 13, Expected '{' and instead saw 'continue'.
slug.js: line 33, col 13, Expected '{' and instead saw 'lengths'.
slug.js: line 37, col 22, 'i' is already defined.
slug.js: line 37, col 29, 'l' is already defined.
slug.js: line 44, col 20, Expected '{' and instead saw 'return'.
slug.js: line 45, col 10, Don't make functions within a loop.
slug.js: line 61, col 26, Expected '{' and instead saw 'char'.
slug.js: line 68, col 7, Expected '{' and instead saw 'result'.
slug.js: line 70, col 2, Unnecessary semicolon.
slug.js: line 193, col 13, Expected '{' and instead saw 'continue'.
slug.js: line 197, col 40, Missing semicolon.
slug.js: line 203, col 18, 'key' is already defined.
slug.js: line 205, col 13, Expected '{' and instead saw 'continue'.
```

Note that,
- I have used `[].forEach()` where appropriate, because it is as well supported in browsers as `[].some()` is, so this is a non breaking change.
- I haven't used `Object.keys()` because it is not as well supported as `[].some`, so some browsers would have suffered from the change.
- I have not changed the algorithm at all, as this in not part of this work.
