### PR TITLE
Throw error if null or undefined

### DIFF
--- a/slug.js
+++ b/slug.js
@@ -10,7 +10,9 @@ function symbols(code) {
 }
 
 function slug(string, opts) {
-    string = (string || '').toString();
+    if (string === null || string === undefined)
+        throw new Error('Slug input must be castable to string')
+    string = string.toString();
     if ('string' === typeof opts)
         opts = {replacement:opts};
     opts = opts || {};

--- a/slug.js
+++ b/slug.js
@@ -10,7 +10,7 @@ function symbols(code) {
 }
 
 function slug(string, opts) {
-    string = string.toString();
+    string = (string || '').toString();
     if ('string' === typeof opts)
         opts = {replacement:opts};
     opts = opts || {};

--- a/test.js
+++ b/test.js
@@ -1,1 +1,3 @@
 console.log(require('./slug')('😹'));
+console.log(require('./slug')('Test'));
+console.log(require('./slug')(null));

--- a/test.js
+++ b/test.js
@@ -1,3 +1,1 @@
 console.log(require('./slug')('😹'));
-console.log(require('./slug')('Test'));
-console.log(require('./slug')(null));


### PR DESCRIPTION
If undefined is passed in, this will return an empty string instead of an error. Not sure if this error is preferred to just returning an empty string though.
