### PR TITLE
chore(ci): add Node 0.12, 4, 5 & 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,7 @@ language: node_js
 node_js:
     - 0.8
     - 0.10
+    - 0.12
+    - 4
+    - 5
+    - 6


### PR DESCRIPTION
The issue with Node 6 is quite deep in the dependency tree,

| - [node-unicode-table](https://github.com/dodo/node-unicodetable)
| - - [bufferstream](https://github.com/dodo/node-bufferstream)
| - - - [bufferjs](https://github.com/coolaj86/node-bufferjs)

The problem is [here](https://github.com/coolaj86/node-bufferjs/blob/master/bufferjs/indexOf.js#L16) because `buffer.get` was deprecated in Node 4 and [removed](https://github.com/nodejs/node/commit/101bca988c) in Node 6. Since this is excessively old code, we could probably update `node-unicodetable` to use a different buffer interface, such as [node-stream-buffer](https://github.com/samcday/node-stream-buffer)
