### PR TITLE
Fixed two bugs with handling of the replacement character + tests

### DIFF
--- a/slug.js
+++ b/slug.js
@@ -9,6 +9,13 @@ function symbols(code) {
     return _symbols[code];
 }
 
+function escapeChar(ch) {
+    if (!ch) { return ""; }
+    var out = ch.charCodeAt(0).toString(16);
+    while (out.length < 4) { out = "0" + out; }
+    return "\\u" + out;
+}
+
 function slug(string, opts) {
     string = string.toString();
     if ('string' === typeof opts)
@@ -61,9 +68,10 @@ function slug(string, opts) {
         if (opts.remove) char = char.replace(opts.remove, ''); // add flavour
         result += char;
     }
+    var replacement_re = escapeChar(opts.replacement);
     result = result.replace(/^\s+|\s+$/g, ''); // trim leading/trailing spaces
-    result = result.replace(/[-\s]+/g, opts.replacement); // convert spaces
-    result = result.replace(opts.replacement+"$",''); // remove trailing separator
+    result = result.replace(new RegExp("[\\s"+replacement_re+"]+", "g"), opts.replacement); // convert spaces
+    result = result.replace(new RegExp("^"+replacement_re+"|"+replacement_re+"$", "g"),''); // remove leading/trailing separators
     if (opts.lower)
       result = result.toLowerCase();
     return result;

--- a/test/slug.test.coffee
+++ b/test/slug.test.coffee
@@ -10,6 +10,11 @@ describe 'slug', ->
         [slug 'foo bar baz', '_'].should.eql ['foo_bar_baz']
         [slug 'foo bar baz', ''].should.eql ['foobarbaz']
 
+    it 'should remove duplicate custom separators', ->
+        text = "looooooooooooool"
+        expected = "lol"
+        [slug text, 'o'].should.eql [expected]
+
     it 'should remove trailing space if any', ->
         [slug ' foo bar baz '].should.eql ['foo-bar-baz']
 
@@ -226,6 +231,11 @@ describe 'slug', ->
     it 'should default to lowercase in rfc3986 mode', ->
       text = "It's Your Journey We Guide You Through."
       expected = "its-your-journey-we-guide-you-through."
+      [slug text, mode:'rfc3986'].should.eql [expected]
+
+    it 'should trim leading / trailing separators', ->
+      text = "--words go here--"
+      expected = "words-go-here"
       [slug text, mode:'rfc3986'].should.eql [expected]
 
     it 'should allow disabling of lowercase', ->


### PR DESCRIPTION
Fixes two bugs I found while reading the source code:
1. The regexp that replaces multiple spaces/separators accidentally hard-codes '-' in the regexp, meaning that this behavior won't work with custom separators.
2. The code that replaces trailing separators doesn't use the regexp constructor, so it will only remove a trailing separator when followed by a '$' character, which is strange. This fixes that behavior, as well as extends it to cover leading separators as well.

This is similar to PR #55, except that this code escapes the separator, so it should still work when the replacement character is a regexp character.
